### PR TITLE
Add detailed installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # daikinskyport
-API and Home Assistant component for accessing a DaikinOne+ Thermostat
+API and [Home Assistant](https://www.home-assistant.io/) component for accessing a [Daikin One+ Smart Thermostat](https://daikinone.com/).
 
 This is currently a work in progress but most functions are supported.  Now welcoming feedback for features and bugs.  This was mostly taken from the ecobee code and modified.
 
-To use, copy the daikinskyport folder to your custom_components folder.
+To use:
 
-Add this to your configuration.yaml:
+1. Copy the `daikinskyport` folder to your `custom_components` folder.
+2. Add this to your `configuration.yaml`:
+
 ```
 daikinskyport:
   email: <your email>
   password: <your password>
 ```
 
-TBD:
-Fix services - not sure what I'm doing wrong, it looks to me the same as the ecobee  
-Get rid of time on weather forecast  
-Would like to understand more of the parameters in the API and get them documented  
+## TODO
+
+- Fix services - not sure what I'm doing wrong, it looks to me the same as the ecobee
+- Get rid of time on weather forecast
+- Would like to understand more of the parameters in the API and get them documented

--- a/README.md
+++ b/README.md
@@ -3,16 +3,49 @@ API and [Home Assistant](https://www.home-assistant.io/) component for accessing
 
 This is currently a work in progress but most functions are supported.  Now welcoming feedback for features and bugs.  This was mostly taken from the ecobee code and modified.
 
-To use:
+## Installation
 
-1. Copy the `daikinskyport` folder to your `custom_components` folder.
-2. Add this to your `configuration.yaml`:
+This component can be installed via the [Home Assistant Community Store (HACS)](https://hacs.xyz/) or manually.
+
+### Install via HACS
+
+_HACS must be [installed](https://hacs.xyz/docs/installation/prerequisites) before following these steps._
+
+1. Log into your Home Assistant instance and open HACS via the sidebar on the left.
+2. In the HACS console, open **Integrations**.
+3. On the integrations page, select the "vertical dots" icon in the top-right corner, and select **Custom respositories**.
+4. Paste `https://github.com/apetrycki/daikinskyport` into the **Add custom repository URL** box and select **Integration** in the **Category** menu.
+5. Select **Add**.
+
+### Manual Install
+
+_A manual installation is more risky than installation via HACS. You must be familiar with how to SSH into Home Assistant and working in the Linux shell to perform these steps._
+
+1. Download or clone the component's repository by selecting the **Code** button on the [component's GitHub page](https://github.com/apetrycki/daikinskyport).
+2. If you downloaded the component as a zip file, extract the file.
+3. Copy the `custom_components/daikinskyport` folder from the repository to your Home Assistant `custom_components` folder. Once done, the full path to the component in Home Assistant should be `/config/custom_components/daikinskyport`. The `__init__.py` file (along with the rest of the files) should be directly in the `daikinskyport` folder.
+
+## Usage
+
+In order for this component to talk with your thermostat, the thermostat must be registered with your online Daikin account. If you haven't already done so, follow the instructions for pairing with the mobile app in the [Daikin documentation](https://backend.daikincomfort.com/docs/default-source/product-documents/residential-accessories/other/hg-one-st.pdf?sfvrsn=c0692726_38).
+
+After pairing the thermostat and installing the component, activate the component by adding the lines below to the Home Assistant `configuration.yaml`. You can find instructions for editing this file in the [Home Assistant documentation](https://www.home-assistant.io/docs/configuration/).
 
 ```
 daikinskyport:
   email: <your email>
   password: <your password>
 ```
+
+The email and password must be the same ones that you used when you created your account in the mobile app.
+
+Indentation is important! The `daikinskyport:` line should be left-aligned with no leading whitespace and the `email:` and `password:` lines should be indented by two spaces.
+
+Restart Home Assistant Core via the Home Assistant console by navigating to **Supervisor** in the sidebar on the left, selecting the **System** tab, and clicking **Restart Core**. A restart is necessary in order to load the component.
+
+Once Core has restarted, navigate to **Configuration** in the sidebar, then **Entities**. Use the search box to search for the name of your thermostat. For example, search for `main room` (the name of your thermostat is shown on the touch screen). You should see a `climate`, `weather`, and a number of `sensor` entities.
+
+**NOTE:** This component does not show up in the list of Home Assistant integrations.
 
 ## TODO
 


### PR DESCRIPTION
- Install via HACS or manually
- Usage: modifying configuration.yaml and then what to look for once you've restarted HA (this tripped me up when I first installed it; I kept searching for "daikin" or "skyport" in the entity name)
