### PR TITLE
Control "emergency heating" mode to the aux heater

### DIFF
--- a/custom_components/daikinskyport/const.py
+++ b/custom_components/daikinskyport/const.py
@@ -47,3 +47,9 @@ DAIKIN_WEATHER_SYMBOL_TO_HASS = {
 # The multiplier applied by the API to percentage values.
 DAIKIN_PERCENT_MULTIPLIER = 2
 
+# Possible hvac modes are auto (3), auxHeatOnly (4), cool (2), heat (1), off (0) '''
+DAIKIN_HVAC_MODE_OFF = 0
+DAIKIN_HVAC_MODE_HEAT = 1
+DAIKIN_HVAC_MODE_COOL = 2
+DAIKIN_HVAC_MODE_AUTO = 3
+DAIKIN_HVAC_MODE_AUXHEAT = 4

--- a/custom_components/daikinskyport/daikinskyport.py
+++ b/custom_components/daikinskyport/daikinskyport.py
@@ -247,7 +247,7 @@ class DaikinSkyport(object):
             return None
 
     def set_hvac_mode(self, index, hvac_mode):
-        ''' possible hvac modes are auto (3), auxHeatOnly (4), cool (2), heat (1), off (0) '''
+        ''' possible modes are DAIKIN_HVAC_MODE_{OFF,HEAT,COOL,AUTO,AUXHEAT} '''
         body = {"mode": hvac_mode}
         log_msg_action = "set HVAC mode"
         return self.make_request(index, body, log_msg_action)


### PR DESCRIPTION
This is a submission for issue #3.  It uses the aux heater functionality in the climate entity to control turning the emergency heating mode on and off.
