### PR TITLE
Use save_json from homeassistant.helpers.json

### DIFF
--- a/custom_components/daikinskyport/__init__.py
+++ b/custom_components/daikinskyport/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     CONF_EMAIL,
 )
 from homeassistant.util import Throttle
-from homeassistant.util.json import save_json
+from homeassistant.helpers.json import save_json
 
 from .daikinskyport import DaikinSkyport
 from .const import (


### PR DESCRIPTION
save_json from homeassistant.util.json is deprecated

Fixes #55