### PR TITLE
Fix ozone unit of measure

### DIFF
--- a/custom_components/daikinskyport/daikinskyport.py
+++ b/custom_components/daikinskyport/daikinskyport.py
@@ -202,7 +202,7 @@ class DaikinSkyport(object):
         if self.thermostats[index]['aqOutdoorAvailable']:
             sensors.append({"name": f"{name} Outdoor", "value": thermostat['aqOutdoorParticles'], "type": "particle"})
             sensors.append({"name": f"{name} Outdoor", "value": thermostat['aqOutdoorValue'], "type": "score"})
-            sensors.append({"name": f"{name} Outdoor", "value": thermostat['aqOutdoorOzone'], "type": "ozone"})
+            sensors.append({"name": f"{name} Outdoor", "value": round(thermostat['aqOutdoorOzone'] * 1.96), "type": "ozone"})
         if self.thermostats[index]['aqIndoorAvailable']:
             sensors.append({"name": f"{name} Indoor", "value": thermostat['aqIndoorParticlesValue'], "type": "particle"})
             sensors.append({"name": f"{name} Indoor", "value": thermostat['aqIndoorValue'], "type": "score"})

--- a/custom_components/daikinskyport/sensor.py
+++ b/custom_components/daikinskyport/sensor.py
@@ -52,7 +52,7 @@ SENSOR_TYPES = {
     },
     "ozone": {
         "device_class": SensorDeviceClass.OZONE,
-        "native_unit_of_measurement": CONCENTRATION_PARTS_PER_BILLION,
+        "native_unit_of_measurement": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": "mdi:cloud",
     },


### PR DESCRIPTION
This integration failed to start in my HA installation (2023.5.3) because "ozone" only supports µg/m³ unit of measure, which it mentions here:

https://www.home-assistant.io/integrations/sensor

This workaround resolves the issue