### PR TITLE
Quick for issue #89

### DIFF
--- a/custom_components/daikinskyport/__init__.py
+++ b/custom_components/daikinskyport/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_NAME,
     Platform
 )
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.util import Throttle
@@ -76,7 +77,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass, config, unique_id, entry
     )
 
-    await coordinator._async_update_data()
+    try:
+        await coordinator._async_update_data()
+    except ExpiredTokenError as ex:
+        _LOGGER.warn("Unable to refresh auth token.")
+        raise ConfigEntryNotReady("Unable to refresh token.")
     
     if coordinator.daikinskyport.thermostats is None:
         _LOGGER.error("No Daikin Skyport devices found to set up")


### PR DESCRIPTION
Catch token expiry exceptions during startup and ensure that it retries until the token is able to be refreshed.

I think there is some other cleanup that could happen in terms of how token refreshes and state updates are handles that would prevent this situation but this PR will at least catch the scenario and ensure the HA will keep retrying setup of the integration until the the Daikin servers are responding successfully.

The issue appears to be triggered when the Daikin servers return multiple error responses (e.g. 500 errors when their servers are having troubles or undergoing maintenance).  In this scenario, the token refresh and integration reload that happens in the exception handler of `_async_update_data` will itself throw an exception and prevent `async_setup_entry` from succeeding.

This change catches that exception and re-throws a `ConfigEntryNotReady` exception which tells HA core to re-attempt setup in the future.

