### PR TITLE
Define _attr_state_class when initializing a new sensor

### DIFF
--- a/custom_components/daikinskyport/sensor.py
+++ b/custom_components/daikinskyport/sensor.py
@@ -152,6 +152,7 @@ class DaikinSkyportSensor(SensorEntity):
         self._index = sensor_index
         self._state = None
         self._native_unit_of_measurement = SENSOR_TYPES[sensor_type]["native_unit_of_measurement"]
+        self._attr_state_class = SENSOR_TYPES[sensor_type]['state_class']
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
The _attr_state_class needs to be defined as the specified in the `SENSOR_TYPES`. This allows the `SensorStateClass.MEASUREMEN` sensors to collect statistics such as temperature, humidity, etc. The statistics can be used in statistic graph card.