### PR TITLE
feat: sensors for equipment fault codes

### DIFF
--- a/API_info.md
+++ b/API_info.md
@@ -201,6 +201,16 @@ Sensors:
 "ctOutdoorPower": outdoor unit power usage; multiply by 10 for Watts
 "ctIndoorPower": indoor unit power usage; usage TBD
 "ctIFCIndoorBlowerAirflow; furnace blower aiflow in CFM"
+"ctAHCriticalFault": Air Handler Critical Fault Code (in decimal)
+"ctAHMinorFault": Air Handler Minor Fault Code (in decimal)
+"ctEEVCoilCriticalFault": EEV Coil Critical Fault Code (in decimal)
+"ctEEVCoilMinorFault": EEV Coil Minor Fault Code (in decimal)
+"ctIFCCriticalFault": Indoor Furnace Critical Fault Code (in decimal)
+"ctIFCMinorFault": Indoor Furnace Minor Fault Code (in decimal)
+"ctOutdoorCriticalFault": Outdoor Critical Fault Code (in decimal)
+"ctOutdoorMinorFault": Outdoor Minor Fault Code (in decimal)
+"ctStatCriticalFault": Thermostat Critical Fault Code (in decimal)
+"ctStatMinorFault": Thermostat Minor Fault Code (in decimal)
 #Add CFM
 ```
 [n]: Forecast day 1 through 5

--- a/custom_components/daikinskyport/daikinskyport.py
+++ b/custom_components/daikinskyport/daikinskyport.py
@@ -273,6 +273,23 @@ class DaikinSkyport(object):
             sensors.append({"name": f"{name} Indoor", "value": thermostat['aqIndoorValue'], "type": "score"})
             sensors.append({"name": f"{name} Indoor", "value": thermostat['aqIndoorVOCValue'], "type": "VOC"})
 
+        fault_sensors = [
+            ("ctAHCriticalFault", "Air Handler Critical Fault"),
+            ("ctAHMinorFault", "Air Handler Minor Fault"),
+            ("ctEEVCoilCriticalFault", "EEV Coil Critical Fault"),
+            ("ctEEVCoilMinorFault", "EEV Coil Minor Fault"),
+            ("ctIFCCriticalFault", "Indoor Furnace Critical Fault"),
+            ("ctIFCMinorFault", "Indoor Furnace Minor Fault"),
+            ("ctOutdoorCriticalFault", "Outdoor Critical Fault"),
+            ("ctOutdoorMinorFault", "Outdoor Minor Fault"),
+            ("ctStatCriticalFault", "Thermostat Critical Fault"),
+            ("ctStatMinorFault", "Thermostat Minor Fault"),
+        ]
+
+        for fault_key, fault_name in fault_sensors:
+            if fault_key in thermostat:
+                sensors.append({"name": f"{name} {fault_name}", "value": thermostat[fault_key], "type": "fault_code"})
+
         return sensors
 
     def write_tokens_to_file(self):

--- a/custom_components/daikinskyport/sensor.py
+++ b/custom_components/daikinskyport/sensor.py
@@ -203,7 +203,10 @@ class DaikinSkyportSensor(SensorEntity):
                 # handler) is not present and therefore has no valid state. Experience
                 # shows that 255 also indicates an issue with the component. In
                 # either case, we do not return any value for the sensor.
-                if sensor["type"] == "fault_code" and sensor["value"] != 255:
-                    self._state = sensor["value"]
+                if sensor["type"] == "fault_code":
+                    if sensor["value"] == 255:
+                        continue
+                    else:
+                        self._state = sensor["value"]
                 elif not sensor["value"] == 65535 and not sensor["value"] == 655350:
                     self._state = sensor["value"]

--- a/custom_components/daikinskyport/sensor.py
+++ b/custom_components/daikinskyport/sensor.py
@@ -199,9 +199,11 @@ class DaikinSkyportSensor(SensorEntity):
         sensors = self.data.daikinskyport.get_sensors(self._index)
         for sensor in sensors:
             if sensor["type"] == self._type and self._sensor_name == sensor["name"]:
-                # A fault code of 255 indicates that piece of equipment (eg, the air
-                # handler) is not present and therefore has no valid state.
-                if sensor["type"] == "fault_code" and sensor["value"] == 255:
-                    self._state = None
+                # A fault code of 255 indicates that component (eg, the air
+                # handler) is not present and therefore has no valid state. Experience
+                # shows that 255 also indicates an issue with the component. In
+                # either case, we do not return any value for the sensor.
+                if sensor["type"] == "fault_code" and sensor["value"] != 255:
+                    self._state = sensor["value"]
                 elif not sensor["value"] == 65535 and not sensor["value"] == 655350:
                     self._state = sensor["value"]


### PR DESCRIPTION
These sensors can be used to monitor the fault codes reported by various pieces of equipment in the system. Any value > 0 indicates an active fault. For each of these thermostat properties, a sensor is created with the indicated name:

ctAHCriticalFault: Air Handler Critical Fault Code
ctAHMinorFault: Air Handler Minor Fault Code
ctEEVCoilCriticalFault: EEV Coil Critical Fault Code
ctEEVCoilMinorFault: EEV Coil Minor Fault Code
ctIFCCriticalFault: Indoor Furnace Critical Fault Code
ctIFCMinorFault: Indoor Furnace Minor Fault Code
ctOutdoorCriticalFault: Outdoor Critical Fault Code
ctOutdoorMinorFault: Outdoor Minor Fault Code
ctStatCriticalFault: Thermostat Critical Fault Code
ctStatMinorFault: Thermostat Minor Fault

If a given piece of equipment isn't part of the system, the sensor is still created but will have an 'unknown' value.