### PR TITLE
Add humidity control support to climate entity

### DIFF
--- a/custom_components/daikinskyport/climate.py
+++ b/custom_components/daikinskyport/climate.py
@@ -392,6 +392,8 @@ class Thermostat(ClimateEntity):
     _attr_precision = PRECISION_TENTHS
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_fan_modes = [FAN_AUTO, FAN_ON, FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_SCHEDULE]
+    _attr_min_humidity = 25
+    _attr_max_humidity = 65
     _attr_name = None
     _attr_has_entity_name = True
     _enable_turn_on_off_backwards_compatibility = False
@@ -405,6 +407,7 @@ class Thermostat(ClimateEntity):
         self._attr_unique_id = f"{self.thermostat['id']}-climate"
         self._cool_setpoint = self.thermostat["cspActive"]
         self._heat_setpoint = self.thermostat["hspActive"]
+        self._attr_target_humidity = self.thermostat.get("humSP")
         self._hvac_mode = DAIKIN_HVAC_TO_HASS[self.thermostat["mode"]]
         if DAIKIN_FAN_TO_HASS[self.thermostat["fanCirculate"]] == FAN_ON:
             self._fan_mode = DAIKIN_FAN_TO_HASS[self.thermostat["fanCirculateSpeed"] + 3]
@@ -449,6 +452,7 @@ class Thermostat(ClimateEntity):
         self.thermostat = self.data.daikinskyport.get_thermostat(self.thermostat_index)
         self._cool_setpoint = self.thermostat["cspActive"]
         self._heat_setpoint = self.thermostat["hspActive"]
+        self._attr_target_humidity = self.thermostat.get("humSP")
         self._hvac_mode = DAIKIN_HVAC_TO_HASS[self.thermostat["mode"]]
         if DAIKIN_FAN_TO_HASS[self.thermostat["fanCirculate"]] == FAN_ON:
             self._fan_mode = DAIKIN_FAN_TO_HASS[self.thermostat["fanCirculateSpeed"] + 3]
@@ -476,7 +480,10 @@ class Thermostat(ClimateEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return SUPPORT_FLAGS
+        features = SUPPORT_FLAGS
+        if self.thermostat.get("ctSystemCapHumidification", False):
+            features |= ClimateEntityFeature.TARGET_HUMIDITY
+        return features
 
     @property
     def name(self):
@@ -770,6 +777,8 @@ class Thermostat(ClimateEntity):
     def set_humidity(self, humidity):
         """Set the humidity level."""
         self.data.daikinskyport.set_humidity(self.thermostat_index, humidity)
+        self._attr_target_humidity = humidity
+        self.update_without_throttle = True
 
     def set_hvac_mode(self, hvac_mode):
         """Set HVAC mode (auto, auxHeatOnly, cool, heat, off)."""


### PR DESCRIPTION
## Summary
- Advertise existing `set_humidity()` functionality via `ClimateEntityFeature.TARGET_HUMIDITY`
- Only enable humidity control when `ctSystemCapHumidification` capability is present
- Set humidity range to 25-65% (matching Daikin humidifier limits)

## Test plan
- [x] Verify humidity slider appears in climate entity card when system has humidification capability
- [x] Test setting humidity via the slider updates the thermostat
- [x] Verify humidity target is properly loaded on startup and updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)