### PR TITLE
Read Home setpoints when the schedule is disabled

### DIFF
--- a/custom_components/daikinskyport/climate.py
+++ b/custom_components/daikinskyport/climate.py
@@ -405,8 +405,15 @@ class Thermostat(ClimateEntity):
         self.thermostat = thermostat
         self._name = self.thermostat["name"]
         self._attr_unique_id = f"{self.thermostat['id']}-climate"
-        self._cool_setpoint = self.thermostat["cspActive"]
-        self._heat_setpoint = self.thermostat["hspActive"]
+        if not self.thermostat["geofencingAway"] and not self.thermostat["schedEnabled"]:
+            # With the schedule disabled the thermostat honors csp/hspHome, but the
+            # cloud keeps csp/hspActive mirroring csp/hspSched, so Active is not the
+            # setpoint actually in effect.
+            self._cool_setpoint = self.thermostat["cspHome"]
+            self._heat_setpoint = self.thermostat["hspHome"]
+        else:
+            self._cool_setpoint = self.thermostat["cspActive"]
+            self._heat_setpoint = self.thermostat["hspActive"]
         self._attr_target_humidity = self.thermostat.get("humSP")
         self._hvac_mode = DAIKIN_HVAC_TO_HASS[self.thermostat["mode"]]
         if DAIKIN_FAN_TO_HASS[self.thermostat["fanCirculate"]] == FAN_ON:
@@ -450,8 +457,15 @@ class Thermostat(ClimateEntity):
             await self.data._async_update_data()
 
         self.thermostat = self.data.daikinskyport.get_thermostat(self.thermostat_index)
-        self._cool_setpoint = self.thermostat["cspActive"]
-        self._heat_setpoint = self.thermostat["hspActive"]
+        if not self.thermostat["geofencingAway"] and not self.thermostat["schedEnabled"]:
+            # With the schedule disabled the thermostat honors csp/hspHome, but the
+            # cloud keeps csp/hspActive mirroring csp/hspSched, so Active is not the
+            # setpoint actually in effect.
+            self._cool_setpoint = self.thermostat["cspHome"]
+            self._heat_setpoint = self.thermostat["hspHome"]
+        else:
+            self._cool_setpoint = self.thermostat["cspActive"]
+            self._heat_setpoint = self.thermostat["hspActive"]
         self._attr_target_humidity = self.thermostat.get("humSP")
         self._hvac_mode = DAIKIN_HVAC_TO_HASS[self.thermostat["mode"]]
         if DAIKIN_FAN_TO_HASS[self.thermostat["fanCirculate"]] == FAN_ON:


### PR DESCRIPTION
Fixes #152.

When `schedEnabled` is false (permanent hold / "Manual" preset), `set_permanent_hold()` writes the setpoint to `cspHome`/`hspHome`, but `climate.py` reads it back from `cspActive`/`hspActive`. With the schedule disabled the cloud keeps `cspActive` mirroring `cspSched`, so HA shows the setpoint of the **disabled** schedule rather than the one in effect.

On my unit (ONETOUCH), with `schedEnabled: false`:

```
cspActive = 21.6  (70.9F)   <- what HA displayed
cspSched  = 21.6  (70.9F)   <- identical to cspActive
cspHome   = 20.6  (69.1F)   <- what the thermostat/app actually use
```

It persisted for days, and the displayed value tracked my configured schedule's daily transitions while the preset stayed `Manual`. Details and full evidence in #152.

This reads the Home setpoints only when the schedule is disabled and geofencing away is inactive, mirroring the precedence already used for presets (`geofencingAway` > `schedOverride` > `schedEnabled`). **It is a no-op whenever the schedule is enabled**, so it cannot change behavior for schedule users.

Applied at both the `__init__` and `async_update` sites, matching the file's existing duplication of that block.

Out of scope: `set_temp_hold()` (`schedOverride: 1`) also writes `cspHome` and may be affected the same way, but I have not measured that case so I left it alone.
