### PR TITLE
Change heat/cool setpoints for schedule from int to float to support systems configured to use Celcius.

### DIFF
--- a/custom_components/daikinskyport/climate.py
+++ b/custom_components/daikinskyport/climate.py
@@ -194,8 +194,8 @@ THERMOSTAT_SCHEDULE_SCHEMA = vol.Schema(
         vol.Optional(ATTR_SCHEDULE_PART): cv.positive_int,
         vol.Optional(ATTR_SCHEDULE_PART_ENABLED): cv.boolean,
         vol.Optional(ATTR_SCHEDULE_PART_LABEL): cv.string,
-        vol.Optional(ATTR_SCHEDULE_HEATING_SETPOINT): cv.positive_int,
-        vol.Optional(ATTR_SCHEDULE_COOLING_SETPOINT): cv.positive_int,
+        vol.Optional(ATTR_SCHEDULE_HEATING_SETPOINT): cv.positive_float,
+        vol.Optional(ATTR_SCHEDULE_COOLING_SETPOINT): cv.positive_float,
     }
 )
 


### PR DESCRIPTION
Hi, I recently tried to use the `daikin_set_thermostat_schedule` service to update the schedule on my system but found that any partial degrees I had for my heat or cool set points where being converted to whole numbers.  I assume integers were used for the schema because floating point values don't make sense (or aren't supported) when systems are configured for Fahrenheit.  But my system uses Celsius where at least half-degrees are supported by Daikin.

I just updated the schema for the set schedule call to use floats instead of ints.  I think this should still work fine for Fahrenheit systems as the value will likely just be implicitly converted to an int.

Maybe it makes sense to change this conditionally based on which temperature system the Daikin units are using but I didn't see any way to determine that.